### PR TITLE
Fix the examples for the `sign` command

### DIFF
--- a/api-docs/commands/sign.xml
+++ b/api-docs/commands/sign.xml
@@ -35,20 +35,6 @@
         <cli_example><![CDATA[]]></cli_example>
         <rpc_example><![CDATA[curl -X POST https://test.stellar.org:9002 -d '
 {
-  "command": "sign",
-  "secret" : "s3q5ZGX2ScQK2rJ4JATp7rND6X5npG3De8jMbB7tuvm2HAVHcCN",
-  "tx_json" : {
-    "TransactionType": "Payment",
-    "Account":"ganVp9o5emfzpwrG5QVUXqMv8AgLcdvySb",
-    "Destination": "gHJPw9kW8v4BsUyDnBR8ZHWo8aEkhUMeAq",
-    "Amount": {
-      "currency": "USD",
-      "issuer": "ghj4kXtHfQcCaLQwpLJ11q2hq6248R7k9C",
-      "value": 10
-    }
-  }
-}']]></rpc_example>
-        <ws_example><![CDATA[{
   "method": "sign",
   "params": [{
     "secret" : "s3q5ZGX2ScQK2rJ4JATp7rND6X5npG3De8jMbB7tuvm2HAVHcCN",
@@ -63,6 +49,20 @@
       }
     }
   }]
+}']]></rpc_example>
+        <ws_example><![CDATA[{
+  "command": "sign",
+  "secret" : "s3q5ZGX2ScQK2rJ4JATp7rND6X5npG3De8jMbB7tuvm2HAVHcCN",
+  "tx_json" : {
+    "TransactionType": "Payment",
+    "Account":"ganVp9o5emfzpwrG5QVUXqMv8AgLcdvySb",
+    "Destination": "gHJPw9kW8v4BsUyDnBR8ZHWo8aEkhUMeAq",
+    "Amount": {
+      "currency": "USD",
+      "issuer": "ghj4kXtHfQcCaLQwpLJ11q2hq6248R7k9C",
+      "value": 10
+    }
+  }
 }
             ]]></ws_example>
     </command>


### PR DESCRIPTION
The rpc and websocket examples were reversed.
