### PR TITLE
Fix `account_info` websocket example

### DIFF
--- a/api-docs/commands/account_info.xml
+++ b/api-docs/commands/account_info.xml
@@ -73,8 +73,8 @@
 }']]></rpc_example>
         <ws_example><![CDATA[{
   "command": "account_info",
-  "id": 24,
-  "account": "gM4Fpv2QuHY4knJsQyYGKEHFGw3eMBwc1U"
+  "ledger_index": 400,
+  "account": "ganVp9o5emfzpwrG5QVUXqMv8AgLcdvySb"
 }]]></ws_example>
     </command>
 </commands>


### PR DESCRIPTION
The websocket example for `account_info` referenced a bad account.

Replace the `id` parameter with `ledger_index`, to match the rpc
example. I don't know what `id` is, but the websocket example should
match the rpc one.
