### PR TITLE
Fix search order of stellar.txt

### DIFF
--- a/docs/Stellar.txt.md
+++ b/docs/Stellar.txt.md
@@ -9,8 +9,8 @@ Any web site can publish Stellar network information. This is useful to announce
 Given the domain "DOMAIN", the stellar.txt will be searched for in this order:
 
 - https:/<span></span>/stellar.DOMAIN/stellar.txt
-- https:/<span></span>/www.DOMAIN/stellar.txt
 - https:/<span></span>/DOMAIN/stellar.txt
+- https:/<span></span>/www.DOMAIN/stellar.txt
 
 ### Enabling cross-origin resource sharing (CORS)
 You must enable CORS on the stellar.txt so people can access this file from other sites, the following HTTP header MUST be set for all requests to stellar.txt and its dependent files.


### PR DESCRIPTION
As you can see from the reference client (see https://github.com/stellar/stellar-client/blob/master/app/scripts/services/stellartxt.js#L28), stellar.txt files are searching in a different order than what is described in the docs.

Unless, the client code is incorrect?
