### PR TITLE
Remove onecred from list of Gateways

### DIFF
--- a/docs/gateway-list.md
+++ b/docs/gateway-list.md
@@ -1,5 +1,6 @@
 Gateways supporting multi-currency on the Stellar client
 ========================================================
 This is a community-contributed list of gateways. The Stellar Development Foundation does not endorse any of these companies.
-* [onecred](https://onecred.com/)
+
 * [coinexgateway.com](https://coinexgateway.com)
+* [ripplefox.com](https://ripplefox.com) 


### PR DESCRIPTION
Remove onecred from list of Gateways supporting multi-currency on the stellar network. 

Fixes https://github.com/stellar/docs/issues/31