### PR TITLE
remove interstellar from root learn page

### DIFF
--- a/learn/readme.md
+++ b/learn/readme.md
@@ -24,10 +24,4 @@ Horizon provides a RESTful API to allow client applications to interact with the
 ## [SDKs](../horizon/learn/#libraries)
 The SDKs facilitate communication between Horizon and a client application that is interacting with the Stellar network. They are responsible for crafting and signing transactions, submitting requests to Horizon, processing the responses, etc.
 
-## [Interstellar](../interstellar/learn/)
-The Interstellar Module System is a collection of modules that aims to make it easy to build a web application on the Stellar network. Interstellar is built using the [JavaScript Stellar SDK](https://github.com/stellar/js-stellar-sdk).
-
-Think of Interstellar as a bootstrap for building Stellar clients. Read more about the [design philosophy of Interstellar](https://www.stellar.org/blog/developer-preview-interstellar-module-system/).
-
-
-`stellar-core` <-> `horizon`  <-> `js-stellar-sdk` <-> `interstellar`
+`stellar-core` <-> `horizon`  <-> `js-stellar-sdk`

--- a/learn/readme.md
+++ b/learn/readme.md
@@ -24,4 +24,4 @@ Horizon provides a RESTful API to allow client applications to interact with the
 ## [SDKs](../horizon/learn/#libraries)
 The SDKs facilitate communication between Horizon and a client application that is interacting with the Stellar network. They are responsible for crafting and signing transactions, submitting requests to Horizon, processing the responses, etc.
 
-`stellar-core` <-> `horizon`  <-> `js-stellar-sdk`
+`stellar-core` <-> `horizon`  <-> `stellar-sdk` <-> `your client application`


### PR DESCRIPTION
This is so that people do not get confused and start reading interstellar docs when the sdk or Horizon docs are more what they need.

### Ecosystem image still references interstellar; shall I crop it out?
![image](https://cloud.githubusercontent.com/assets/5728307/13227750/0fd26c9e-d94d-11e5-96ac-aebc542f37f5.png)
