### PR TITLE
change seed to secret key in code framework

### DIFF
--- a/learn/integration-guides/exchange.md
+++ b/learn/integration-guides/exchange.md
@@ -60,7 +60,7 @@ For this guide, we use placeholder functions for reading/writing to the exchange
 // Config your server
 var config = {};
 config.baseAccount = "your base account address";
-config.baseAccountSeed = "your base account seed";
+config.baseAccountSecret = "your base account secret key";
 
 // You can use Stellar.org's instance of Horizon or your own
 config.horizon = 'https://horizon-testnet.stellar.org';
@@ -214,7 +214,7 @@ function submitTransaction(exchangeAccount, destinationAddress, amountLumens) {
           amount: amountLumens
         }))
         // Sign the transaction
-        .addSigner(StellarSdk.Keypair.fromSeed(config.baseAccountSeed))
+        .addSigner(StellarSdk.Keypair.fromSecret(config.baseAccountSecret))
         .build();
       // POST https://horizon-testnet.stellar.org/transactions
       return server.submitTransaction(transaction);
@@ -228,7 +228,7 @@ function submitTransaction(exchangeAccount, destinationAddress, amountLumens) {
           // Creating an account requires funding it with XLM
           startingBalance: amountLumens
         }))
-        .addSigner(StellarSdk.Keypair.fromSeed(config.baseAccountSeed))
+        .addSigner(StellarSdk.Keypair.fromSecret(config.baseAccountSecret))
         .build();
       // POST https://horizon-testnet.stellar.org/transactions
       return server.submitTransaction(transaction);


### PR DESCRIPTION
Since we're using "secret key" rather than "seed," I've revised the code sample. H/t to @irisli for the suggestion.