### PR TITLE
Re-write of guides landing page

### DIFF
--- a/learn/readme.md
+++ b/learn/readme.md
@@ -1,27 +1,21 @@
 ---
-title: Learn Overview
+title: Stellar Development Guides
 ---
-# The Stellar Ecosystem
 
-![Stellar Ecosystem](https://www.stellar.org/wp-content/uploads/2015/08/ecosystem-overview-2.png)
+These guides are designed to help you learn more about the technical aspects of integrating Stellar into your application or service, from [the very basics](./get-started) to more detailed topics like [submitting transactions at a high rate with channels](./channels.md).
 
-The Stellar ecosystem is made up of several pieces of software. Depending on what you're doing with Stellar, you'll interact with or run different pieces of the ecosystem.
+If you are looking for detailed documentation on Stellar’s HTTP API or client libraries for your favorite programming language, check out the [API Reference](../reference) section.
 
-## [Stellar Core](https://github.com/stellar/stellar-core)
-Stellar Core, or stellar-core, is the backbone of the Stellar network. It maintains a local copy of the ledger, communicating and staying in sync with other instances of stellar-core on the network. The Stellar network is made up of a collection of stellar-cores run by various individuals and entities all connected to each other. Stellar-core carries out the Stellar Consensus Protocol (SCP) and comes to consensus about the state of the network.
+Some guides are grouped together:
 
-stellar-core accepts a limited number of [commands](https://github.com/stellar/stellar-core/blob/master/docs/learn/commands.md).
+## Get Started
 
-stellar-core writes its state out to a SQL DB that other applications can read to follow changes to the global [ledger](./concepts/ledger.md).
+The [“Get Started” guide](./get-started) will introduce you to the basic technical aspects of Stellar, starting with an introduction to the various parts of the Stellar network, then moving on to programmatically creating accounts, and finally performing transactions.
 
-It can also be configured to send historical data to a `history store`. Every stellar-core needs to use *some* history store in order to catch up to the network, but not every stellar-core needs to write out its own history store.
+## Concepts
 
-## [Horizon](../horizon/learn/)
-Horizon is the client-facing API server for the Stellar ecosystem. As the interface between stellar-core and applications that want to access the Stellar network, Horizon allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc.
+The “Concepts” section contains overviews and explanations of various objects, terms, and technologies used throughout the Stellar ecosystem, from [accounts](./concepts/transactions.md) to the details of the [Stellar Consensus Protocol](./concepts/scp.md) that underlies everything.
 
-Horizon provides a RESTful API to allow client applications to interact with the Stellar network. You can communicate with Horizon using cURL or just your web browser. However, if you're building a client application, you'll likely want to use a [Stellar SDK](https://www.stellar.org/developers/horizon/learn/#libraries) in the language of your client.
+## SDKs
 
-## [SDKs](../horizon/learn/#libraries)
-The SDKs facilitate communication between Horizon and a client application that is interacting with the Stellar network. They are responsible for crafting and signing transactions, submitting requests to Horizon, processing the responses, etc.
-
-`stellar-core` <-> `horizon`  <-> `stellar-sdk` <-> `your client application`
+Looking for more details on Stellar’s client SDKs? You can find detailed documentation for each client SDK in the [API Reference](../reference) section.


### PR DESCRIPTION
This is partially because the content of the old page will be subsumed into the getting started guide in #136 and partially because this just needs to be a decent intro to this part of the site.