### PR TITLE
Remove link to security guide (it doesn't exist yet)

### DIFF
--- a/learn/get-started/transactions.md
+++ b/learn/get-started/transactions.md
@@ -281,7 +281,6 @@ You can read more about the details of assets in the [assets overview](../concep
 Now that you can send and receive payments using Stellar’s API, you’re on your way to writing all kinds of amazing financial software. Experiment with other parts of the API, then read up on more detailed topics:
 
 - [Become an anchor](../anchor.md)
-- [Security](../security.md)
 - [Federation](../concepts/federation.md)
 - [Compliance](../compliance-protocol.md)
 


### PR DESCRIPTION
Since the security guide doesn’t actually exist in the developers site yet, we probably shouldn’t link to it!

(I guess I need to convert that draft to Markdown and make a PR for it, but is it really quite ready yet?)

@bartekn @jessica-collier 