### PR TITLE
Update federation server source code URLs

### DIFF
--- a/guides/concepts/federation.md
+++ b/guides/concepts/federation.md
@@ -37,7 +37,7 @@ Please note that your federation server **must** use `https` protocol.
 
 The federation URL specified in your stellar.toml file should accept an HTTP GET request and issue responses of the form detailed below.
 
-Instead of building your own server you can use the [`federation server`](https://github.com/stellar/federation) built by Stellar Development Foundation.
+Instead of building your own server you can use the [`federation server`](https://github.com/stellar/go/tree/master/services/federation) built by Stellar Development Foundation.
 
 ## Federation Requests
 You can use the federation endpoint to look up an account id if you have a stellar address. You can also do reverse federation and look up a stellar addresses from account ids or transaction ids. This is useful to see who has sent you a payment.

--- a/guides/things-to-build.md
+++ b/guides/things-to-build.md
@@ -28,7 +28,7 @@ A relatively simple project that graphically displays information pulled from Ho
 # Federation Service
 Implement a simple [Federation server](https://www.stellar.org/developers/guides/concepts/federation.html) and setup a webpage where anyone can claim a name*yourdomain.com stellar address and associate their stellar account ID with it. The catch is your service will only federate for accounts that set their [inflation destination](https://www.stellar.org/developers/guides/concepts/inflation.html) to one provided by your domain.
 
-You can also contribute to the [federation server](https://github.com/stellar/federation/) maintained by Stellar Development Foundation.
+You can also contribute to the [federation server](https://github.com/stellar/go/tree/master/services/federation) maintained by Stellar Development Foundation.
 
 # Lumens to any email address
 Allow anyone to send lumens from their Stellar client to any email address. They would simply enter in something like `<emailaddress>*domain.com` and then they are able to send it lumens. If the recipient doesn't have a stellar account already one will be created for them and they will get an email alerting them that they have lumens.


### PR DESCRIPTION
It looks like the federation server moved from the https://github.com/stellar/federation repo to the https://github.com/stellar/go repo, so this just updates all thinks (that I could find) in the docs so people don't land on a page that says "DEPRECATED!"