### PR TITLE
Add 'display_decimals' to stellar.toml doc

### DIFF
--- a/guides/concepts/stellar-toml.md
+++ b/guides/concepts/stellar-toml.md
@@ -144,10 +144,12 @@ HISTORY=[
 [[CURRENCIES]]
 code="USD"
 issuer="GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM"
+display_decimals=2 # How many decimal places should be displayed by clients to end users.
 
 [[CURRENCIES]]
 code="BTC"
 issuer="$anchor"
+display_decimals=8
 
 
 #   Potential quorum set of this domain's validatos.


### PR DESCRIPTION
As discussed on slack, 'display_decimals' gives a hint to clients as to how many decimal places should be displayed when formatting amounts to end users.