### PR TITLE
Compliance doc updates

### DIFF
--- a/guides/compliance-protocol.md
+++ b/guides/compliance-protocol.md
@@ -34,7 +34,7 @@ Name | Data Type | Description
 `sender` | string | The stellar address of the customer that is initiating the send. Ex. `jed*stellar.org`
 `need_info` | boolean | If the caller needs the recipient's AML info in order to send the payment.
 `tx` | string: base64 encoded [xdr.Transaction](https://github.com/stellar/stellar-core/blob/4961b8bb4a64c68838632c5865389867e9f02840/src/xdr/Stellar-transaction.x#L297-L322) | The transaction that the sender would like to send in XDR format. This transaction is unsigned.
-`memo` | string | The full text of the memo. The hash of this memo is included in the transaction. The **memo** field follows the [Stellar memo convention](https://github.com/stellar/stellar-protocol/issues/28) and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
+`memo` | string | The full text of the memo. The hash of this memo is included in the transaction. The **memo** field follows the [memo preimage](./memo-preimage.md) structure and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
 
 **sig** is the signature of the data block made by the sending FI. The receiving institution should check that this signature is valid against the public signature key that is posted in the sending FI's [stellar.toml](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) (`SIGNING_KEY` field).
 
@@ -64,7 +64,7 @@ Name | Data Type | Description
 -----|-----------|------------
 `info_status` | `ok`, `denied`, `pending` | If this FI is willing to share AML information or not.
 `tx_status` | `ok`, `denied`, `pending` | If this FI is willing to accept this transaction.
-`dest_info` | string | *(only present if `info_status` is `ok`)* Marshalled JSON of the recipient's AML information in the [Stellar memo convention](https://github.com/stellar/stellar-protocol/issues/28).
+`dest_info` | string | *(only present if `info_status` is `ok`)* Marshalled JSON of the recipient's AML information in the [memo preimage](./memo-preimage.md).
 `pending` | integer | *(only present if `info_status` or `tx_status` is `pending`)* Estimated number of seconds till the sender can check back for a change in status. The sender should just resubmit this request after the given number of seconds.
 
 *Response Example*

--- a/guides/compliance-protocol.md
+++ b/guides/compliance-protocol.md
@@ -22,7 +22,7 @@ The `AUTH_SERVER` provides one endpoint that is called by a sending FI to get ap
 
 #### Request
 
-To send transaction data to receiving organization, send HTTP POST to `AUTH_SERVER` with `Content-Type` equal `application/x-www-form-urlencoded` and the following body:
+To send transaction data to the receiving organization, send HTTP POST to `AUTH_SERVER` with `Content-Type` equal `application/x-www-form-urlencoded` and the following body:
 ```
 data=<data value>&sig=<sig value>
 ```
@@ -31,10 +31,10 @@ data=<data value>&sig=<sig value>
 
 Name | Data Type | Description
 -----|-----------|------------
-`sender` | string | The stellar address of the customer that is initiating the send. Ex. `jed*stellar.org`
+`sender` | string | The payment address of the customer that is initiating the send. Ex. `bob*bank.com`
 `need_info` | boolean | If the caller needs the recipient's AML info in order to send the payment.
 `tx` | string: base64 encoded [xdr.Transaction](https://github.com/stellar/stellar-core/blob/4961b8bb4a64c68838632c5865389867e9f02840/src/xdr/Stellar-transaction.x#L297-L322) | The transaction that the sender would like to send in XDR format. This transaction is unsigned.
-`memo` | string | The full text of the memo. The hash of this memo is included in the transaction. The **memo** field follows the [memo preimage](./memo-preimage.md) structure and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
+`attach` | string | The full text of the attachment. The hash of this attachment is included as a memo in the transaction. The **attach** field follows the [Stellar Attachment Convention](./attachment.md) and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
 
 **sig** is the signature of the data block made by the sending FI. The receiving institution should check that this signature is valid against the public signature key that is posted in the sending FI's [stellar.toml](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) (`SIGNING_KEY` field).
 
@@ -43,18 +43,18 @@ Example request body (please note it contains both parameters `data` and `sig`):
 data=%7B%22sender%22%3A%22aldi*bankA.com%22%2C%22need_info%22%3Atrue%2C%22tx%22%3A%22AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D%22%2C%22memo%22%3A%22%7B%22transaction%22%3A%20%7B%22route%22%3A%20%22bogart*bankB.com%22%2C%20%22sender_info%22%3A%20%22%7B%5C%22name%5C%22%3A%20%5C%22Aldi%20Dobbs%5C%22%2C%20%5C%22address%5C%22%3A%20%5C%22678%20Mission%20St%2C%20San%20Francisco%2C%20CA%5C%22%7D%22%7D%7D%22%7D&sig=rphsdQJQPvKU7gF%2FwpmeeId9tJUM3eNqB%2FgaQykGO6IHcfpePquRBdwkxZuYVTRNtQlK3GrU%2FxvY5KoX3mQMBA%3D%3D
 ```
 
-After decoding `data` parameter it has a following form:
+After decoding the `data` parameter it has a following form:
 
 ```json
 {
   "sender": "aldi*bankA.com",
   "need_info": true,
   "tx": "AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8/mUo8/2RP7UQh0qX/2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA=",
-  "memo": "{\"transaction\": {\"route\": \"bogart*bankB.com\", \"sender_info\": \"{\\\"name\\\": \\\"Aldi Dobbs\\\", \\\"address\\\": \\\"678 Mission St, San Francisco, CA\\\"}\"}}"
+  "attach": "{\"transaction\": {\"route\": \"bogart*bankB.com\", \"sender_info\": \"{\\\"name\\\": \\\"Aldi Dobbs\\\", \\\"address\\\": \\\"678 Mission St, San Francisco, CA\\\"}\"}}"
 }
 ```
 
-Please note that memo value of `tx` is sha256 hash of memo string. You can check the transaction above using [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D&type=Transaction&network=test).
+Please note that the memo value of `tx` is a sha256 hash of the attachment. You can check the transaction above using [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D&type=Transaction&network=test).
 
 #### Response
 
@@ -136,7 +136,7 @@ After decoding `data` parameter it has a following form:
 }
 ```
 
-Please note that memo value of `tx` is sha256 hash of memo string and payment destination is a destination returned by federation server. You can check the transaction above using [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D&type=Transaction&network=test).
+Please note that memo value of `tx` is the sha256 hash of the attachment and payment destination is returned by the federation server. You can check the transaction above using the [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D&type=Transaction&network=test).
 
 **4) BankB handles the Auth request**
 

--- a/guides/compliance-protocol.md
+++ b/guides/compliance-protocol.md
@@ -18,43 +18,63 @@ You can create your own endpoint that implements the compliance protocol or we h
 
 ## AUTH_SERVER
 
-The AUTH_SERVER provides one endpoint that is called by a sending FI to get approval to send a payment to one of the receiving FI's customers. It is also used by the sender to follow up if the initial request wasn't able to complete in real time, i.e. either `info_status` or `tx_status` returned pending. The sender will simply call the AUTH_SERVER endpoint after the suggested time has past.
+The `AUTH_SERVER` provides one endpoint that is called by a sending FI to get approval to send a payment to one of the receiving FI's customers. The `AUTH_SERVER` url should be placed in organization's [stellar.toml](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) file.
 
-HTTP POST to `https://AUTH_SERVER?data=<json>&sig=<sender sig of data>`
+#### Request
 
+To send transaction data to receiving organization, send HTTP POST to `AUTH_SERVER` with `Content-Type` equal `application/x-www-form-urlencoded` and the following body:
+```
+data=<data value>&sig=<sig value>
+```
 
 **data** is a block of JSON that contains the following fields:
 
-Name | Description
------|------
-sender | The stellar address of the customer that is initiating the send.
-need_info | If the caller needs the recipient's AML info in order to send the payment.
-tx |  The transaction that the sender would like to send in XDR format. This transaction is unsigned.
-memo | The full text of the memo. The hash of this memo is included in the transaction. The **memo** field follows the [Stellar memo convention](https://github.com/stellar/stellar-protocol/issues/28) and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
+Name | Data Type | Description
+-----|-----------|------------
+`sender` | string | The stellar address of the customer that is initiating the send. Ex. `jed*stellar.org`
+`need_info` | boolean | If the caller needs the recipient's AML info in order to send the payment.
+`tx` | string: base64 encoded [xdr.Transaction](https://github.com/stellar/stellar-core/blob/4961b8bb4a64c68838632c5865389867e9f02840/src/xdr/Stellar-transaction.x#L297-L322) | The transaction that the sender would like to send in XDR format. This transaction is unsigned.
+`memo` | string | The full text of the memo. The hash of this memo is included in the transaction. The **memo** field follows the [Stellar memo convention](https://github.com/stellar/stellar-protocol/issues/28) and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
 
-**sig** is the signature of the data block made by the sending FI. The receiving institution should check that this signature is valid against the public signature key that is posted in the sending FI's [stellar.toml](https://www.stellar.org/developers/guides/concepts/stellar-toml.html).
+**sig** is the signature of the data block made by the sending FI. The receiving institution should check that this signature is valid against the public signature key that is posted in the sending FI's [stellar.toml](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) (`SIGNING_KEY` field).
 
-
-#### Reply
-Will return a JSON object with the following fields:
-
-Name | Description
-----|-----
-info_status | If this FI is willing to share AML information or not. {ok, denied, pending}
-tx_status | If this FI is willing to accept this transaction. {ok, denied, pending}
-dest_info | *(only present if info_status is ok)* JSON of the recipient's AML information. in the [Stellar memo convention](https://github.com/stellar/stellar-protocol/issues/28).
-pending | *(only present if info_status or tx_status is pending)* Estimated number of seconds till the sender can check back for a change in status. The sender should just resubmit this request after the given number of seconds.
-
-*Reply Example*
+Example request body (please note it contains both parameters `data` and `sig`):
 ```
+data=%7B%22sender%22%3A%22aldi*bankA.com%22%2C%22need_info%22%3Atrue%2C%22tx%22%3A%22AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D%22%2C%22memo%22%3A%22%7B%22transaction%22%3A%20%7B%22route%22%3A%20%22bogart*bankB.com%22%2C%20%22sender_info%22%3A%20%22%7B%5C%22name%5C%22%3A%20%5C%22Aldi%20Dobbs%5C%22%2C%20%5C%22address%5C%22%3A%20%5C%22678%20Mission%20St%2C%20San%20Francisco%2C%20CA%5C%22%7D%22%7D%7D%22%7D&sig=rphsdQJQPvKU7gF%2FwpmeeId9tJUM3eNqB%2FgaQykGO6IHcfpePquRBdwkxZuYVTRNtQlK3GrU%2FxvY5KoX3mQMBA%3D%3D
+```
+
+After decoding `data` parameter it has a following form:
+
+```json
 {
-    info_status: "ok",
-    tx_status: "pending",
-    dest_info: {
-        type: "encrypt",
-        value: "TGV0IHlvdXIgaG9wZXMsIG5vdCB5b3VyIGh1cnRzLCBzaGFwZSB5b3VyIGZ1dHVyZS4="
-    },
-    pending: 3600
+  "sender": "aldi*bankA.com",
+  "need_info": true,
+  "tx": "AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8/mUo8/2RP7UQh0qX/2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA=",
+  "memo": "{\"transaction\": {\"route\": \"bogart*bankB.com\", \"sender_info\": \"{\\\"name\\\": \\\"Aldi Dobbs\\\", \\\"address\\\": \\\"678 Mission St, San Francisco, CA\\\"}\"}}"
+}
+```
+
+Please note that memo value of `tx` is sha256 hash of memo string. You can check the transaction above using [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D&type=Transaction&network=test).
+
+#### Response
+
+`AUTH_SERVER` will return a JSON object with the following fields:
+
+Name | Data Type | Description
+-----|-----------|------------
+`info_status` | `ok`, `denied`, `pending` | If this FI is willing to share AML information or not.
+`tx_status` | `ok`, `denied`, `pending` | If this FI is willing to accept this transaction.
+`dest_info` | string | *(only present if `info_status` is `ok`)* Marshalled JSON of the recipient's AML information in the [Stellar memo convention](https://github.com/stellar/stellar-protocol/issues/28).
+`pending` | integer | *(only present if `info_status` or `tx_status` is `pending`)* Estimated number of seconds till the sender can check back for a change in status. The sender should just resubmit this request after the given number of seconds.
+
+*Response Example*
+
+```json
+{
+    "info_status": "ok",
+    "tx_status": "pending",
+    "dest_info": "{\"name\": \"John Doe\"}",
+    "pending": 3600
 }
 ```
 
@@ -64,68 +84,66 @@ pending | *(only present if info_status or tx_status is pending)* Estimated numb
 
 
 ## Example of Flow
-In this example, Aldi `aldi*bankA.com` wants to send to Bogart `bogart*bankB.com`
+In this example, Aldi `aldi*bankA.com` wants to send to Bogart `bogart*bankB.com`:
 
 **1) BankA gets the info needed to interact with BankB**
 
 This is done by looking up BankB's `stellar.toml` file.
 
-BankA  -> fetches `bankB.com/.well-known/stellar.toml`
+BankA  -> fetches `https://bankB.com/.well-known/stellar.toml`
 
 from this .toml file it pulls out the following info for BankB:
- - FEDERATION_SERVER
- - AUTH_SERVER
- - ENCRYPTION_KEY
- - Needed AML fields?
-
+ - `FEDERATION_SERVER`
+ - `AUTH_SERVER`
 
 **2) BankA gets the routing info for Bogart so it can build the transaction**
 
 This is done by asking BankB's federation server to resolve `bogart*bankB.com`.
 
-BankA -> `https://FEDERATION_SERVER?type=name&q=bogart*bankB.com[&simple_aml=true]`
+BankA -> `FEDERATION_SERVER?type=name&q=bogart*bankB.com`
 
 See [Federation](https://www.stellar.org/developers/guides/concepts/federation.html) for a complete description. The returned fields of interest here are:
  - Stellar AccountID of Bogart's FI
  - Bogart's routing info
- - Need Auth flag that says whether BankB needs to authorize the transaction or not.
- - aml_yes *only returned if simple_aml is true*
 
+Example federation response:
+```json
+{
+  "stellar_address": "bogart*bankB.com",
+  "account_id": "GDJ2GYMIQRIPTJZXQAVE5IM675ITLBAMQJS7AEFIWM4HZNGHVXOZ3TZK"
+}
+```
 
 **3) BankA makes the Auth Request to BankB**
 
 This request will ask BankB for Bogart's AML info and for permission to send to Bogart.
 
-BankA -> `https://AUTH_SERVER?data=<json>&sig=<bankA sig of data>`
+BankA -> `AUTH_SERVER`
 
-Example data JSON
+Example request body (please note it contains both parameters `data` and `sig`):
 ```
+data=%7B%22sender%22%3A%22aldi*bankA.com%22%2C%22need_info%22%3Atrue%2C%22tx%22%3A%22AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D%22%2C%22memo%22%3A%22%7B%22transaction%22%3A%20%7B%22route%22%3A%20%22bogart*bankB.com%22%2C%20%22sender_info%22%3A%20%22%7B%5C%22name%5C%22%3A%20%5C%22Aldi%20Dobbs%5C%22%2C%20%5C%22address%5C%22%3A%20%5C%22678%20Mission%20St%2C%20San%20Francisco%2C%20CA%5C%22%7D%22%7D%7D%22%7D&sig=rphsdQJQPvKU7gF%2FwpmeeId9tJUM3eNqB%2FgaQykGO6IHcfpePquRBdwkxZuYVTRNtQlK3GrU%2FxvY5KoX3mQMBA%3D%3D
+```
+
+After decoding `data` parameter it has a following form:
+
+```json
 {
-    sender: "aldi*bankA.com",
-    need_info: "true",
-    tx: <base64 encoded xdr of the tx>,
-    memo:
-    {
-        type: "encrypt"
-        value: encrypted(
-        {
-            route: <Bogart's routing info>
-            sender_info:
-            {
-                stellar: aldi*bankA.com
-                name: Aldi Dobbs
-                address: <blah>
-            }
-        })
-    }
+  "sender": "aldi*bankA.com",
+  "need_info": true,
+  "tx": "AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8/mUo8/2RP7UQh0qX/2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA=",
+  "memo": "{\"transaction\": {\"route\": \"bogart*bankB.com\", \"sender_info\": \"{\\\"name\\\": \\\"Aldi Dobbs\\\", \\\"address\\\": \\\"678 Mission St, San Francisco, CA\\\"}\"}}"
 }
 ```
 
+Please note that memo value of `tx` is sha256 hash of memo string and payment destination is a destination returned by federation server. You can check the transaction above using [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAACWmRKivpIAYP04lBlY1vwsVqzhHysdzPRKquPDyi0LBAAAAZAAAAAAAAABkAAAAAAAAAAMyQ9plXwM8%2FmUo8%2F2RP7UQh0qX%2F2xW4r6F8KwDbKhlawAAAAEAAAAAAAAAAQAAAADTo2GIhFD5pzeAKk6hnv9RNYQMgmXwEKizOHy0x63dnQAAAAAAAAACVAvkAAAAAAA%3D&type=Transaction&network=test).
+
 **4) BankB handles the Auth request**
 
- - BankB -> fetches `bankA.com/.well-known/stellar.toml`
-   From this it gets BankA's ENCRYPTION_KEY and SIGNING_KEY
- - BankB verifies the signature on the Auth Request was signed with BankA's SIGNING_KEY
+ - BankB gets sender domain by spliting the sender address (`aldi*bankA.com`) in 2 parts: `aldi` and `bankA.com`
+ - BankB -> fetches `https://bankA.com/.well-known/stellar.toml`
+   From this it gets BankA's `SIGNING_KEY`
+ - BankB verifies the signature on the Auth Request was signed with BankA's `SIGNING_KEY`
  - BankB does its sanction check on Aldi. This determines the value of `tx_status`.
  - BankB makes the decision to reveal the AML info of Bogart or not based on the following:
    - Bogart has made their info public
@@ -133,16 +151,23 @@ Example data JSON
    - Bogart has allowed Aldi
    - BankB has allowed BankA
  - If none of the above criteria are met, BankB should ask Bogart if he wants to reveal this info to BankA and accept this payment. In this case BankB will return `info_status: "pending"` in the Auth request reply to give Bogart time to accept the payment or not.
- - If BankB determines it can share the AML info with BankA, it uses BankA's ENCRYPTION_KEY to encrypt Bogart's info and sends this encrypted dest_info back with the reply.
+ - If BankB determines it can share the AML info with BankA, it sends this info in `dest_info` field with the reply.
 
-See [Auth Server Reply](#reply) for potential return values.
+See [Auth Server response](#response) for potential return values.
+
+Example Response:
+
+```json
+{
+    "info_status": "ok",
+    "tx_status": "ok",
+    "dest_info": "{\"name\": \"Bogart Doe\"}",
+}
+```
 
 **5) BankA handles the reply from the Auth request**
 
 If the call to the AUTH_SERVER returned `pending`, BankA must resubmit the request again after the estimated number of seconds.
-
-BankA -> `https://AUTH_SERVER?data=<json>&sig=<bankA sig of data>`
-
 
 **6) BankA does the sanction checks**
 

--- a/guides/memo-preimage.md
+++ b/guides/memo-preimage.md
@@ -15,16 +15,22 @@ Memo preimage is a JSON document with the following structure:
   "transaction": {
     "nonce": "<nonce>",
     "sender_info": {
-      "name": "<name>",
+      "first_name": "<first_name>",
+      "middle_name": "<middle_name>",
+      "last_name": "<last_name>",
       "address": "<address>",
-      "date_of_birth": "<date of birth in YYYY-MM-DD format>"
+      "city": "<city>",
+      "province": "<province>",
+      "country": "<country in ISO 3166-1 alpha-2 format>",
+      "date_of_birth": "<date of birth in YYYY-MM-DD format>",
+      "company_name": "<company_name>"
     },
     "route": "<route>",
     "note": "<note>"
   },
   "operations": [
     {
-      "sender_info": "<sender_info>",
+      "sender_info": <sender_info>,
       "route": "<route>",
       "note": "<note>"
     },
@@ -36,7 +42,7 @@ Memo preimage is a JSON document with the following structure:
 Name | Data Type | Description
 -----|-----------|------------
 `transaction.nonce` | Random string | [Nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce) is a random value. Every transaction you send should have a different value. Nonce is needed to distinguish memos of two transactions sent between the same pair of customers.
-`transaction.sender_info` | JSON | JSON containing KYC info of the sender. This JSON object can be extended with more fields.
+`transaction.sender_info` | JSON | JSON containing KYC info of the sender. This JSON object can be extended with more fields if needed.
 `transaction.route` | string | TODO
 `transaction.note` | string | A note attached to transaction.
 `operations[i]` | | `i`th operation data. Can be omitted if transaction has only one operation.
@@ -73,7 +79,9 @@ var memoPreimage = {
     "nonce": nonce.toString('hex'),
     "sender_info": {
       "name": "Sherlock Holmes",
-      "address": "221B Baker Street, London NW1 6XE, UK",
+      "address": "221B Baker Street",
+      "city": "London NW1 6XE",
+      "country": "UK",
       "date_of_birth": "1854-01-06"
     }
   },

--- a/guides/memo-preimage.md
+++ b/guides/memo-preimage.md
@@ -1,0 +1,98 @@
+---
+title: Memo preimage
+---
+
+# Memo preimage
+
+Sometimes there is a need to send more information about the transaction, for example: KYC info and/or a short note. Such data shouldn't be placed in a [ledger](./concepts/ledger.md) because of it's public nature. Instead, you should create a JSON document: memo preimage, send it to receiver's [Auth server](./compliance-protocol.md) and then attach the sha-256 hash as a memo hash in your transaction.
+
+## Memo preimage structure
+
+Memo preimage is a JSON document with the following structure:
+
+```json
+{
+  "transaction": {
+    "nonce": "<nonce>",
+    "sender_info": {
+      "name": "<name>",
+      "address": "<address>",
+      "date_of_birth": "<date of birth in YYYY-MM-DD format>"
+    },
+    "route": "<route>",
+    "note": "<note>"
+  },
+  "operations": [
+    {
+      "sender_info": "<sender_info>",
+      "route": "<route>",
+      "note": "<note>"
+    },
+    // ...
+  ]
+}
+```
+
+Name | Data Type | Description
+-----|-----------|------------
+`transaction.nonce` | Random string | [Nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce) is a random value. Every transaction you send should have a different value. Nonce is needed to distinguish memos of two transactions sent between the same pair of customers.
+`transaction.sender_info` | JSON | JSON containing KYC info of the sender. This JSON object can be extended with more fields.
+`transaction.route` | string | TODO
+`transaction.note` | string | A note attached to transaction.
+`operations[i]` | | `i`th operation data. Can be omitted if transaction has only one operation.
+`operations[i].sender_info` | JSON | `sender_info` for `i`th operation in the transaction. If empty, will inherit value from `transaction`.
+`operations[i].route` | string | `route` for `i`th operation in the transaction. If empty, will inherit value from `transaction`.
+`operations[i].note` | string | `note` for `i`th operation in the transaction. If empty, will inherit value from `transaction`.
+
+## Calculating memo preimage hash
+
+To calculate memo preimage hash you need to stringify JSON object and calculate `sha-256` hash. In Node.js:
+
+```js
+const crypto = require('crypto');
+const hash = crypto.createHash('sha256');
+
+hash.update(JSON.stringify(memoPreimage));
+var memoHashHex = hash.digest('hex');
+```
+
+To add the hash to your transaction use [`TransactionBuilder.addMemo`](http://stellar.github.io/js-stellar-base/TransactionBuilder.html#addMemo) method.
+
+## Sending memo preimage
+
+Send memo preimage and it's hash (in a transaction) to Auth server of a receiving organization. Read [Compliance protocol](./compliance-protocol.md) doc for more information.
+
+## Example
+
+```js
+var crypto = require('crypto');
+
+var nonce = crypto.randomBytes(16);
+var memoPreimage = {
+  "transaction": {
+    "nonce": nonce.toString('hex'),
+    "sender_info": {
+      "name": "Sherlock Holmes",
+      "address": "221B Baker Street, London NW1 6XE, UK",
+      "date_of_birth": "1854-01-06"
+    }
+  },
+  "operations": [
+    // Operation #1: Payment for Dr. Watson
+    {
+      "route": "watson",
+      "note": "Payment for helping to solve murder case"
+    },
+    // Operation #2: Payment for Mrs. Hudson
+    {
+      "route": "hudson",
+      "note": "Rent"
+    }
+  ]
+};
+
+var hash = crypto.createHash('sha256');
+hash.update(JSON.stringify(memoPreimage));
+var memoHashHex = hash.digest('hex');
+console.log(memoHashHex); // TODO
+```


### PR DESCRIPTION
After talking with a partner who wants to implement Compliance Protocol I realized that this document can be improved:
* I added example requests/responses.
* I added more information on requests format.
* I removed features that aren't there yet (ex. `ENCRYPTION_KEY`, `simple_aml`)

I also found some things that needs to be changed:
* Stellar Memo convention still links to the old spec which isn't used in production. I think we need to describe new Memo convention in a separate doc.
* I noticed this commit: https://github.com/stellar/bridge-server/commit/9e251b6c75c2170310ac79eeefa837efd7778777 It wasn't clear which value should be used in `route` parameter. This needs to be specified in this doc.
* This specification is still not clear on sequence number of `tx` sent in auth request and how to handle multiple transactions with the same memo hash:
  * For `memo` I think we should introduce `nonce` which will be a required, random value field in top level of memo json. Then `memo` value will always be different for any two transactions.
  * If we decide to go with the solution above, sequence number in `tx` can be ignored. The transaction received will be identified by it's memo value only.