### PR TITLE
Federation doc updates

### DIFF
--- a/guides/concepts/federation.md
+++ b/guides/concepts/federation.md
@@ -44,7 +44,7 @@ Instead of building your own server you can use the [`federation server`](https:
 ## Federation Requests
 You can use the federation endpoint to look up an account id if you have a stellar address. You can also do reverse federation and look up a stellar addresses from account ids or transaction ids. This is useful to see who has sent you a payment.
 
-Federation requests are http `GET` request with the following query:
+Federation requests are http `GET` requests with the following form:
 
 `?q=<string to look up>&type=<name,id,txid>`
 
@@ -63,7 +63,7 @@ You must enable CORS on the federation server so clients can send requests from 
 Access-Control-Allow-Origin: *
 ```
 
-When record has been found response should return `200 OK` http status code and the following JSON body:
+When a record has been found the response should return `200 OK` http status code and the following JSON body:
 
 ```
 {
@@ -74,9 +74,9 @@ When record has been found response should return `200 OK` http status code and 
 }
 ```
 
-If redirect is needed the federation server should return `3xx` http status code and immediately redirect user to the correct URL using `Location` header.
+If a redirect is needed the federation server should return `3xx` http status code and immediately redirect the user to the correct URL using the `Location` header.
 
-When record has not been found `404 Not Found` http status code should be returned.
+When a record has not been found `404 Not Found` http status code should be returned.
 
 Every other http status code will be considered an error. The body should contain error details:
 
@@ -91,4 +91,4 @@ Accounts may optionally have a [home domain](./accounts.md#home-domain) specifie
 
 ## Caching
 
-You should never try to cache responses from other federation servers. Some organizations may generate random IDs to protect their users privacy. Those IDs may be changing over time.
+You shouldn't cache responses from federation servers. Some organizations may generate random IDs to protect their users' privacy. Those IDs may change over time.


### PR DESCRIPTION
* Changed memo_hash encoding from `base32` to `base64`.  `base32` has multiple value -> character mappings what can be confusing. Additionally, horizon server is using `base64` encoding for memo hash values.
* Improved request/response details.
* Added "Caching" section. See https://github.com/stellar/go-private/issues/9#issuecomment-267588296.