### PR TITLE
doc: downcase JavaScript `return`

### DIFF
--- a/guides/get-started/transactions.md
+++ b/guides/get-started/transactions.md
@@ -398,7 +398,7 @@ payments.call().then(function handlePage(paymentsPage) {
   paymentsPage.records.forEach(function(payment) {
     // handle a payment
   });
-  Return paymentsPage.next().then(handlePage);
+  return paymentsPage.next().then(handlePage);
 });
 ```
 


### PR DESCRIPTION
Use to say `Return`, which is invalid JavaScript.