### PR TITLE
correct example for joint accounts multi-sig

### DIFF
--- a/guides/concepts/multi-sig.md
+++ b/guides/concepts/multi-sig.md
@@ -96,7 +96,7 @@ Joint account setup:
 ```
   master key weight: 1
   low threshold: 0
-  medium threshold: 0
+  medium threshold: 1
   high threshold: 3
   Bilal's signing key weight: 1
   Carina's signing key weight: 1


### PR DESCRIPTION
The example states that the medium threshold should be one signer for Joint Accounts, but the data is inconsistent with that.