### PR TITLE
Change of assets.md documentation

### DIFF
--- a/guides/concepts/assets.md
+++ b/guides/concepts/assets.md
@@ -49,13 +49,10 @@ Any characters from the set [a-z][A-Z][0-9] are allowed. The code can be any num
 
 
 ### Controlling asset holders
-As an anchor, you can mark the issuing account `AUTHORIZATION REQUIRED`. With this setting, the anchor must approve anyone
-who wants to hold its credit, allowing it to control who its customers are.
+As an anchor, you can mark the issuing account `AUTHORIZATION REQUIRED`. With this setting, the anchor must approve anyone who wants to hold its credit, allowing it to control who its customers are. Approving is done by the anchor by setting the `Authorize` flag of an existing trustline to `true` with the [Allow Trust](./list-of-operations.md#allow-trust) operation.
 
 ### Revoking access
-As an anchor, you can mark the issuing account `AUTHORIZATION REVOCABLE`. With this setting, the anchor can freeze credit
-held by another account. When credit is frozen for a particular account, that account can only send the credit back to the anchor--it can't transfer the credit to any other account.
-This setting allows the issuing account to revoke credit that it accidentally issued or that was obtained improperly.
+As an anchor, you can mark the issuing account `AUTHORIZATION REVOCABLE`. With this setting, the anchor can set `Authorize` flag of existing trustline to `false` with  with the [Allow Trust](./list-of-operations.md#allow-trust) operation, to freeze the credit held by another account. When credit is frozen for a particular account, that account can’t transfer the credit to any other account, not even back to the anchor. This setting allows the issuing account to revoke credit that it accidentally issued or that was obtained improperly.
 
 ## Amount precision and representation
 Each asset amount is encoded as a signed 64-bit integer in the [XDR structures](https://www.stellar.org/developers/horizon/learn/xdr.html). An asset amount unit (that which is seen by end users) is scaled down by a factor of ten million (10,000,000) to arrive at the native 64-bit integer representation. For example, the integer amount value `25,123,456` equals `2.5123456` units of the asset. This scaling allows for **seven decimal places** of precision in human-friendly amount units.


### PR DESCRIPTION
Added reference to allow trust operation and removed false statement that the asset can be sent back to the anchor with authorisation revoked. The issue was detected on testnet and we had an informal answer from Boris , quoting CTO, that the documentation is outdated