### PR TITLE
Update set up an exchange title

### DIFF
--- a/guides/exchange.md
+++ b/guides/exchange.md
@@ -1,8 +1,7 @@
 ---
-title: Set Up an Exchange
+title: Add Stellar to your Exchange
 ---
 
-# Adding Stellar to your Exchange
 This guide will walk you through the integration steps to add Stellar to your exchange. This example uses Node.js and the [JS Stellar SDK](https://github.com/stellar/js-stellar-sdk), but it should be easy to adapt to other languages.
 
 There are many ways to architect an exchange. This guide uses the following design:


### PR DESCRIPTION
As per Boris's recommendation, clarify that exchanges.md is a guide on how to "Add Stellar to your exchange" not on how to "Set up an exchange"

Since the title was changed, I also removed the h1 header tag at the top to remove title duplication.