### PR TITLE
describe auth revoke and auth require flow

### DIFF
--- a/guides/concepts/assets.md
+++ b/guides/concepts/assets.md
@@ -49,10 +49,21 @@ Any characters from the set [a-z][A-Z][0-9] are allowed. The code can be any num
 
 
 ### Controlling asset holders
-As an anchor, you can mark the issuing account `AUTHORIZATION REQUIRED`. With this setting, the anchor must approve anyone who wants to hold its credit, allowing it to control who its customers are. Approving is done by the anchor by setting the `Authorize` flag of an existing trustline to `true` with the [Allow Trust](./list-of-operations.md#allow-trust) operation.
+By default, anyone can create a trustline to accept an asset. However, as an anchor, you can **explicitly authorize** and **revoke** user access to your asset by enabling the following flags on your issuing account (read more [here](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)).
 
-### Revoking access
-As an anchor, you can mark the issuing account `AUTHORIZATION REVOCABLE`. With this setting, the anchor can set `Authorize` flag of existing trustline to `false` with the [Allow Trust](./list-of-operations.md#allow-trust) operation, to freeze the credit held by another account. When credit is frozen for a particular account, that account can’t transfer the credit to any other account, not even back to the anchor. This setting allows the issuing account to revoke credit that it accidentally issued or that was obtained improperly.
+* `AUTHORIZATION REQUIRED`: with this setting, the anchor must approve anyone who wants to hold its asset, allowing it to control who its customers are. Approving is done by the anchor by setting the `Authorize` flag of an existing trustline to **true** with the [Allow Trust](./list-of-operations.md#allow-trust) operation.
+* `AUTHORIZATION REVOCABLE`: with this setting, the anchor can set `Authorize` flag of existing trustline to `false` with the [Allow Trust](./list-of-operations.md#allow-trust) operation, to freeze the asset held by another account. When an asset is frozen for a particular account, that account can’t transfer the asset to any other account, not even back to the anchor. This setting allows the issuing account to revoke assets that it accidentally issued or that was obtained improperly. To use this setting, `AUTHORIZATION REQUIRED` must also be enabled.
+
+**Example flow for an account with `AUTHORIZATION REQUIRED` and `AUTHORIZATION REVOCABLE` enabled:**
+1. User decides he/she wants to accept an asset
+2. User opens a trust line with this asset's issuing account
+3. Issuer authorizes the user's trustline
+5. User can accept and send the asset to whomever else has a trustline open with the issuer
+6. Issuer wants to freeze user's access to asset
+7. Issuer deauthorizes user's trustline
+8. User cannot send or accept this asset
+
+**An alternative flow:** Note it is possible to set these flags later. Maybe you originally allow anyone to open a trustline but later realize this was not a great idea. After issuing this asset, you can then set **both** of the above flags. At this point, everyone with an open trustline retains their authorized status, however you can now revoke trustlines and newly created trustlines must be explicitly authorized.
 
 ## Amount precision and representation
 Each asset amount is encoded as a signed 64-bit integer in the [XDR structures](https://www.stellar.org/developers/horizon/learn/xdr.html). An asset amount unit (that which is seen by end users) is scaled down by a factor of ten million (10,000,000) to arrive at the native 64-bit integer representation. For example, the integer amount value `25,123,456` equals `2.5123456` units of the asset. This scaling allows for **seven decimal places** of precision in human-friendly amount units.

--- a/guides/concepts/assets.md
+++ b/guides/concepts/assets.md
@@ -49,21 +49,27 @@ Any characters from the set [a-z][A-Z][0-9] are allowed. The code can be any num
 
 
 ### Controlling asset holders
-By default, anyone can create a trustline to accept an asset. However, as an anchor, you can **explicitly authorize** and **revoke** user access to your asset by enabling the following flags on your issuing account (read more [here](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)).
+By default, anyone can create a trustline with an asset issuer to accept an asset. However, as an anchor, you can **explicitly authorize** and **revoke** user access to your asset by enabling the following flags on your issuing account (read more [here](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)).
 
 * `AUTHORIZATION REQUIRED`: with this setting, the anchor must approve anyone who wants to hold its asset, allowing it to control who its customers are. Approving is done by the anchor by setting the `Authorize` flag of an existing trustline to **true** with the [Allow Trust](./list-of-operations.md#allow-trust) operation.
-* `AUTHORIZATION REVOCABLE`: with this setting, the anchor can set `Authorize` flag of existing trustline to `false` with the [Allow Trust](./list-of-operations.md#allow-trust) operation, to freeze the asset held by another account. When an asset is frozen for a particular account, that account can’t transfer the asset to any other account, not even back to the anchor. This setting allows the issuing account to revoke assets that it accidentally issued or that was obtained improperly. To use this setting, `AUTHORIZATION REQUIRED` must also be enabled.
+* `AUTHORIZATION REVOCABLE`: with this setting, the anchor can set `Authorize` flag of existing trustline to `false` with the [Allow Trust](./list-of-operations.md#allow-trust) operation, to freeze the asset held by another account. When an asset is frozen for a particular account, that account can’t transfer the asset to any other account, not even back to the anchor. This setting allows the issuing account to revoke assets that it accidentally issued or that were obtained improperly. To use this setting, `AUTHORIZATION REQUIRED` must also be enabled.
 
 **Example flow for an account with `AUTHORIZATION REQUIRED` and `AUTHORIZATION REVOCABLE` enabled:**
 1. User decides he/she wants to accept an asset
 2. User opens a trust line with this asset's issuing account
 3. Issuer authorizes the user's trustline
-5. User can accept and send the asset to whomever else has a trustline open with the issuer
-6. Issuer wants to freeze user's access to asset
-7. Issuer deauthorizes user's trustline
-8. User cannot send or accept this asset
+4. User can accept and send the asset to whomever else has a trustline open with the issuer
+5. Issuer wants to freeze user's access to asset
+6. Issuer deauthorizes user's trustline
+7. User cannot send or accept this asset
 
-**An alternative flow:** Note it is possible to set these flags later. Maybe you originally allow anyone to open a trustline but later realize this was not a great idea. After issuing this asset, you can then set **both** of the above flags. At this point, everyone with an open trustline retains their authorized status, however you can now revoke trustlines and newly created trustlines must be explicitly authorized.
+**An alternative flow:** note it is possible to set these flags later. Maybe you originally allow anyone to open a trustline but later realize this was not a great idea. After issuing this asset, you can then set **both** of the above flags. At this point, everyone with an open trustline retains their authorized status, however you can now revoke trust (assuming you have not adjusted your master key weight and/or [account thresholds](./multi-sig.md#thresholds)) .
+
+**Note:** when anchors issue assets, they often wish to limit the supply of tokens in circulation. It is still possible to create this limited supply and maintain the ability to authorize and revoke because the [Allow Trust](./list-of-operations.md#allow-trust)  operation is `low threshold` while the [Set Options](./list-of-operations.md#set-options)  and [Payment](./list-of-operations.md#payment) operations are `high/medium threshold`. To learn more about creating assets and limiting token supply [read here](../walkthroughs/custom-assets.md#optional-transaction-a-limit-token-supply). 
+
+**Ensuring asset holders they won't be revoked**: the above functionalities are great for asset issuers who wish to control who can and cannot hold/transact their asset. However, what if I am an asset holder and I am worried that an issuer may freeze the assets I hold? To instill trust in potential asset holders, the issuing account can enable the following flag:
+
+* `AUTHORIZATION IMMUTABLE`: with this setting, none of the authorization flags can be set and the account can never be deleted.
 
 ## Amount precision and representation
 Each asset amount is encoded as a signed 64-bit integer in the [XDR structures](https://www.stellar.org/developers/horizon/learn/xdr.html). An asset amount unit (that which is seen by end users) is scaled down by a factor of ten million (10,000,000) to arrive at the native 64-bit integer representation. For example, the integer amount value `25,123,456` equals `2.5123456` units of the asset. This scaling allows for **seven decimal places** of precision in human-friendly amount units.


### PR DESCRIPTION
After some discussions with Boris and other partner/user facing members of the team, I thought it might be a good idea to rewrite this section to make it a bit clearer how `Authorization_required` and `Authorization_revoke` work.

Essentially, I:

a) kept the current auth require and authorize revoke descriptions
b) made it clear that these flags are not set by default and to obtain these functionalities, the flags must be set
c) Added two example user flows to make it easier to understand how/why these flags may be used
