### PR TITLE
Remove unused var from example.

### DIFF
--- a/guides/issuing-assets.md
+++ b/guides/issuing-assets.md
@@ -279,7 +279,6 @@ The following example sets authorization to be both required and revocable:
 
 ```js
 StellarSdk.Network.useTestNetwork();
-var flags = StellarSdk.xdr.AccountFlags;
 var transaction = new StellarSdk.TransactionBuilder(issuingAccount)
   .addOperation(StellarSdk.Operation.setOptions({
     setFlags: StellarSdk.AuthRevocableFlag | StellarSdk.AuthRequiredFlag


### PR DESCRIPTION
It seems like the var was there for legacy reasons but now the Global constants are used in `setFlag`.