### PR TITLE
Added COINQVEST Full Validators/History Archives

### DIFF
--- a/validators.md
+++ b/validators.md
@@ -44,6 +44,15 @@ Contact | coinplaycenter@gmail.com (email), soufrilasp@gmail.com (email), Panagi
 NodeID | GBFKPET5EK4YDXAD24CQV5XIRFVHQPDPHU2T34ELEMKUPNPFG2MAZBBJ
 Status | ![Online](https://img.shields.io/badge/status-online-brightgreen.svg)
 
+------
+Name | COINQVEST
+-----|--------
+Description | https://www.coinqvest.com/.well-known/stellar.toml
+Contact | service[at]coinqvest.com
+NodeID | GADLA6BJK6VK33EM2IDQM37L5KGVCY5MSHSHVJA4SCNGNUIEOTCR6J5T GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN
+Peer |  finland.stellar.coinqvest.com (Finland) <br/> germany.stellar.coinqvest.com	(Germany)
+Status | ![Online](https://img.shields.io/badge/status-online-brightgreen.svg)
+
 -----
 Name | Collegecoin
 ---|---

--- a/validators.md
+++ b/validators.md
@@ -49,7 +49,7 @@ Name | COINQVEST
 -----|--------
 Description | https://www.coinqvest.com/.well-known/stellar.toml
 Contact | service[at]coinqvest.com
-NodeID | GADLA6BJK6VK33EM2IDQM37L5KGVCY5MSHSHVJA4SCNGNUIEOTCR6J5T GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN
+NodeID | GADLA6BJK6VK33EM2IDQM37L5KGVCY5MSHSHVJA4SCNGNUIEOTCR6J5T <br /> GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN
 Peer |  finland.stellar.coinqvest.com (Finland) <br/> germany.stellar.coinqvest.com	(Germany)
 Status | ![Online](https://img.shields.io/badge/status-online-brightgreen.svg)
 


### PR DESCRIPTION
Hello!

We'd like to add our validators to the list, please.

You can inspect the state of each validator by viewing the static info URLs (they update every minute):

-> https://finland.stellar.coinqvest.com/info.json
-> https://germany.stellar.coinqvest.com/info.json

The validators run with CATCHUP_COMPLETE=true and we've implemented two public history archives. Information on how to use the archives (along with our quorum configuration) is included in our stellar.toml:

-> https://www.coinqvest.com/.well-known/stellar.toml

Would it be a good idea to publish a list of known history archives along with the list of known validators on the dashboard and Stellar website in the future? Currently it is hard to find any independent history archives and all new validators basically have to use the SDF ones. Food for thought?

Please let me know anytime if there are questions.

Thanks and have a nice day!

PS: We are COINQVEST and we're here to help online merchants to easily receive and manage crypto payments. We'll be live in 2019.