### PR TITLE
Suggesting certain image types to include in toml file

### DIFF
--- a/guides/walkthroughs/how-to-complete-stellar-toml.md
+++ b/guides/walkthroughs/how-to-complete-stellar-toml.md
@@ -289,7 +289,7 @@ they will list your token.
 * Any conditions you place on the redemption of your token (`conditions`).
 * A URL to a PNG or GIF image with a transparent background representing your token (`image`). Without it, your token will appear blank on many exchanges.
 * anchor_asset_type
-* anchor_asset/
+* anchor_asset
 
 Here's what an example of completed Currency Documentation for an organization:
 

--- a/guides/walkthroughs/how-to-complete-stellar-toml.md
+++ b/guides/walkthroughs/how-to-complete-stellar-toml.md
@@ -287,8 +287,7 @@ they will list your token.
 * A description of your token and what it represents (`desc`).  This is a good place to clarify
   what your token does, and why someone might want to own it.
 * Any conditions you place on the redemption of your token (`conditions`).
-* A URL to a PNG image with a transparent background representing your token (`image`). Without it, your token will appear blank on many
-  exchanges.
+* A URL to a PNG or GIF image with a transparent background representing your token (`image`). Without it, your token will appear blank on many exchanges.
 * anchor_asset_type
 * anchor_asset/
 

--- a/guides/walkthroughs/how-to-complete-stellar-toml.md
+++ b/guides/walkthroughs/how-to-complete-stellar-toml.md
@@ -287,10 +287,10 @@ they will list your token.
 * A description of your token and what it represents (`desc`).  This is a good place to clarify
   what your token does, and why someone might want to own it.
 * Any conditions you place on the redemption of your token (`conditions`).
-* A URL to an image representing token (`image`). Without it, your token will appear blank on many
+* A URL to a PNG image with a transparent background representing your token (`image`). Without it, your token will appear blank on many
   exchanges.
 * anchor_asset_type
-* anchor_asset
+* anchor_asset/
 
 Here's what an example of completed Currency Documentation for an organization:
 
@@ -318,7 +318,7 @@ display_decimals=2
 name="goat share"
 desc="1 GOAT token entitles you to a share of revenue from Elkins Goat Farm."
 conditions="There will only ever be 10,000 GOAT tokens in existence. We will distribute the revenue share annually on Jan. 15th"
-image="https://pbs.twimg.com/profile_images/666921221410439168/iriHah4f.jpg"
+image="https://static.thenounproject.com/png/2292360-200.png"
 fixed_number=10000
 ```
 


### PR DESCRIPTION
When digging through some toml files I noticed a handful people are using jpg images or images without transparent backgrounds for their logo. 

I could be nitpicking, but I think we should suggest using logos with transparent backgrounds and certain file formats. Mostly to make developers and especially designers lives easier when pulling images from toml files. 

Also changed the example image to a goat icon with a transparent background. 