### PR TITLE
Use full routes to get-started guide

### DIFF
--- a/guides/readme.md
+++ b/guides/readme.md
@@ -2,7 +2,7 @@
 title: Stellar Development Guides
 ---
 
-These guides are designed to help you learn more about the technical aspects of integrating Stellar into your application or service, from [the very basics](./get-started) to more detailed topics like [submitting transactions at a high rate with channels](./channels.md).
+These guides are designed to help you learn more about the technical aspects of integrating Stellar into your application or service, from [the very basics](./get-started/index.html) to more detailed topics like [submitting transactions at a high rate with channels](./channels.md).
 
 If you are looking for detailed documentation on Stellar’s HTTP API or client libraries for your favorite programming language, check out the [API Reference](../reference) section.
 
@@ -10,7 +10,7 @@ Some guides are grouped together:
 
 ## Get Started
 
-The [Get Started guide](./get-started) will introduce you to the basic technical aspects of Stellar, starting with an introduction to the various parts of the Stellar network, then moving on to address programmatically creating accounts and performing transactions.
+The [Get Started guide](./get-started/index.html) will introduce you to the basic technical aspects of Stellar, starting with an introduction to the various parts of the Stellar network, then moving on to address programmatically creating accounts and performing transactions.
 
 ## Concepts
 


### PR DESCRIPTION
Without these full routes, the link at the bottom of the Get Started page (https://www.stellar.org/developers/guides/get-started) for "Next: Create an Account" will be https://www.stellar.org/developers/guides/create-account.html (which is 404) instead of https://www.stellar.org/developers/guides/get-started/create-account.html (which is correct).