### PR TITLE
doc fixes related to anchor guide

### DIFF
--- a/guides/anchor/4-compliance-server.md
+++ b/guides/anchor/4-compliance-server.md
@@ -20,7 +20,7 @@ When another compliance server contacts yours to clear a transaction, a series o
 
 ## Create a Database
 
-The compliance server requires a MySQL or PostgreSQL database in order to save transaction and compliance information. Create a new database named `stellar_compliance` and a user to manage it. You don’t need to add any tables; the server includes [a command to configure and update your database](#start-the-server).
+The compliance server requires a PostgreSQL database in order to save transaction and compliance information. Create a new database named `stellar_compliance` and a user to manage it. You don’t need to add any tables; the server includes [a command to configure and update your database](#start-the-server).
 
 
 ## Download and Configure Compliance Server
@@ -39,8 +39,8 @@ needs_auth = false
 network_passphrase = "Test SDF Network ; September 2015"
 
 [database]
-type = "mysql" # Or "postgres" if you created a PostgreSQL database
-url = "dbuser:dbpassword@/stellar_compliance"
+type = "postgres"
+url = "postgres://dbuser@dbhost/compliance"
 
 [keys]
 # This should be the secret seed for your base account (or another account that

--- a/guides/walkthroughs/custom-assets.md
+++ b/guides/walkthroughs/custom-assets.md
@@ -136,7 +136,6 @@ By submitting Transaction 6, the created token will be listed on the Stellar Net
 Examples for some of the transactions and more about issuing assets can be found [here](../issuing-assets.md). In addition, [this article](../concepts/assets.md#anchors-issuing-assets) provides more in-depth explanations of key terms regarding asset creation. A preliminary guide that walks through explaining token creation using Stellar Laboratory is available [here](https://www.stellar.org/blog/tokens-on-stellar/).
 
 ## Resources:
-- [Becoming an Anchor](../anchor/) - Stellar<span>.org
 - [Minimum Account Balance Calculation](../concepts/fees.md#minimum-account-balance) - Stellar<span>.org
 - [Concept: stellar.toml](../concepts/stellar-toml.md) - Stellar<span>.org
 - [Concept: Trustlines](../concepts/assets.md#trustlines) - Stellar<span>.org


### PR DESCRIPTION
- remove link to outdate anchor guide from custom assets doc
- remove mysql from compliance server guide since it's not longer supported