### PR TITLE
Updating the JavaScript SDK url

### DIFF
--- a/reference/readme.md
+++ b/reference/readme.md
@@ -3,7 +3,7 @@ title: Horizon Reference Overview
 ---
 Horizon is the client-facing API server for the Stellar ecosystem.  It acts as the interface between [Stellar Core](https://github.com/stellar/stellar-core) and applications that want to access the Stellar network. Horizon allows you to submit transactions to the network, check the status of accounts, and subscribe to event streams. For more details, see an [overview of the Stellar network](https://www.stellar.org/developers/guides/).
 
-You can interact directly with Horizon via cURL or a web browser. Stellar.org also provides a [JavaScript SDK](https://www.stellar.org/developers/js-stellar-sdk/learn/) for clients to use to interact with Horizon.
+You can interact directly with Horizon via cURL or a web browser. Stellar.org also provides a [JavaScript SDK](https://www.stellar.org/developers/js-stellar-sdk/reference/index.html) for clients to use to interact with Horizon.
 
 Stellar.org runs an [instance of Horizon](https://horizon-testnet.stellar.org/) that is connected to the [testnet](../guides/concepts/test-net.md).
 


### PR DESCRIPTION
The previous url `https://www.stellar.org/developers/js-stellar-sdk/learn/` returns 404 not found