### PR TITLE
Remove mentions of MySQL in Federation docs

### DIFF
--- a/guides/anchor/3-federation-server.md
+++ b/guides/anchor/3-federation-server.md
@@ -16,7 +16,7 @@ Stellar.org provides a [prebuilt federation server](https://github.com/stellar/g
 
 ## Create a Database
 
-The Stellar federation server is designed to connect to any existing SQL database you might have with a list of account names. It essentially translates a federation request into a SQL query. The server supports MySQL, PostgreSQL, and SQLite3.
+The Stellar federation server is designed to connect to any existing SQL database you might have with a list of account names. It essentially translates a federation request into a SQL query. The server supports PostgreSQL, and SQLite3.
 
 At a minimum, your database should have a table with a column identifying the name to use for each account record.[^federation_tables] In your existing system, you might have a table named `accounts` that looks something like:
 
@@ -41,8 +41,8 @@ Next, [download the latest federation server](https://github.com/stellar/go/rele
 port = 8002
 
 [database]
-type = "mysql" # Or "postgres" or "sqlite3"
-dsn = "dbuser:dbpassword@/internal_accounts"
+type = "postgres" # Or "sqlite3"
+dsn = "postgres://dbuser@dbhost/internal_accounts?sslmode=sslmode"
 
 [queries]
 federation = "SELECT 'GAIGZHHWK3REZQPLQX5DNUN4A32CSEONTU6CMDBO7GDWLPSXZDSYA4BU' as id, friendly_id as memo, 'text' as memo_type FROM accounts WHERE friendly_id = ? AND ? = 'your_org.com'"

--- a/guides/anchor/3-federation-server.md
+++ b/guides/anchor/3-federation-server.md
@@ -16,7 +16,7 @@ Stellar.org provides a [prebuilt federation server](https://github.com/stellar/g
 
 ## Create a Database
 
-The Stellar federation server is designed to connect to any existing SQL database you might have with a list of account names. It essentially translates a federation request into a SQL query. The server supports PostgreSQL, and SQLite3.
+The Stellar federation server is designed to connect to any existing SQL database you might have with a list of account names. It essentially translates a federation request into a SQL query. The server supports PostgreSQL and SQLite3.
 
 At a minimum, your database should have a table with a column identifying the name to use for each account record.[^federation_tables] In your existing system, you might have a table named `accounts` that looks something like:
 

--- a/translations/pt-BR/guides/anchor/3-federation-server.md
+++ b/translations/pt-BR/guides/anchor/3-federation-server.md
@@ -41,8 +41,8 @@ Em seguida, [faça download do servidor federation mais recente](https://github.
 port = 8002
 
 [database]
-type = "mysql" # Ou "postgres" ou "sqlite3"
-dsn = "dbusuario:dbsenha@/internal_accounts"
+type = "postgres" # Ou "sqlite3"
+dsn = "postgres://dbusuario@db____/internal_accounts?sslmode=sslmod"
 
 [queries]
 federation = "SELECT 'GAIGZHHWK3REZQPLQX5DNUN4A32CSEONTU6CMDBO7GDWLPSXZDSYA4BU' as id, friendly_id as memo, 'text' as memo_type FROM accounts WHERE friendly_id = ? AND ? = 'sua_org.com'"

--- a/translations/pt-BR/guides/anchor/3-federation-server.md
+++ b/translations/pt-BR/guides/anchor/3-federation-server.md
@@ -16,7 +16,7 @@ Stellar.org fornece um [servidor federation pré-construído](https://github.com
 
 ## Criar uma Base de Dados
 
-O servidor federation Stellar é feito para conectar com qualquer base de dados SQL que você tiver que contenha uma lista de nomes de contas. Em essência, o servidor traduz uma request federation para um query SQL. O servidor dá suporte a MySQL, PostgreSQL, e SQLite3.
+O servidor federation Stellar é feito para conectar com qualquer base de dados SQL que você tiver que contenha uma lista de nomes de contas. Em essência, o servidor traduz uma request federation para um query SQL. O servidor dá suporte a PostgreSQL e SQLite3.
 
 Sua base de dados deve ter, no mínimo, uma tabela com uma coluna que identifica o nome a ser usado para cada registro de conta.[^federation_tables] Em seu sistema, você pode ter uma tabela de nome `accounts` com mais ou menos essa cara:
 

--- a/translations/pt-BR/guides/anchor/3-federation-server.md
+++ b/translations/pt-BR/guides/anchor/3-federation-server.md
@@ -16,7 +16,7 @@ Stellar.org fornece um [servidor federation pré-construído](https://github.com
 
 ## Criar uma Base de Dados
 
-O servidor federation Stellar é feito para conectar com qualquer base de dados SQL que você tiver que contenha uma lista de nomes de contas. Em essência, o servidor traduz uma request federation para um query SQL. O servidor dá suporte a PostgreSQL e SQLite3.
+O servidor federation Stellar é feito para conectar com qualquer base de dados SQL que você tiver que contenha uma lista de nomes de contas. Em essência, o servidor traduz uma request federation para um query SQL. O servidor dá suporte a MySQL, PostgreSQL, e SQLite3.
 
 Sua base de dados deve ter, no mínimo, uma tabela com uma coluna que identifica o nome a ser usado para cada registro de conta.[^federation_tables] Em seu sistema, você pode ter uma tabela de nome `accounts` com mais ou menos essa cara:
 
@@ -41,8 +41,8 @@ Em seguida, [faça download do servidor federation mais recente](https://github.
 port = 8002
 
 [database]
-type = "postgres" # Ou "sqlite3"
-dsn = "postgres://dbusuario@db____/internal_accounts?sslmode=sslmod"
+type = "mysql" # Ou "postgres" ou "sqlite3"
+dsn = "dbusuario:dbsenha@/internal_accounts"
 
 [queries]
 federation = "SELECT 'GAIGZHHWK3REZQPLQX5DNUN4A32CSEONTU6CMDBO7GDWLPSXZDSYA4BU' as id, friendly_id as memo, 'text' as memo_type FROM accounts WHERE friendly_id = ? AND ? = 'sua_org.com'"


### PR DESCRIPTION
Remove mention of MySQL in Federation docs, to bring the docs inline with stellar/go#1753 and future versions of Federation that are released.

Close stellar/go#1736.