### PR TITLE
Point to validators channel, on Keybase now

### DIFF
--- a/validators.md
+++ b/validators.md
@@ -2,7 +2,7 @@ Stellar.org supports the network by running a few full validators and Horizon in
 
 If you would like to run a validator please:
  - Read the [admin guide](https://www.stellar.org/developers/stellar-core/learn/admin.html).
- - Join the #validators channel on [our slack](http://slack.stellar.org).
+ - Join the #validators channel on [our Keybase team](https://keybase.io/team/stellar.public).
  - See the [example config](./other/stellar-core-validator-example.cfg) for setting up your validator.
  - Start your node.
  - Open a pull request to list it here.


### PR DESCRIPTION
Not Slack....

Note that at some point, references to people via Slack identities in this document should also be changed as appropriate.