### PR TITLE
Fix timeout in Python example

### DIFF
--- a/guides/get-started/transactions.md
+++ b/guides/get-started/transactions.md
@@ -236,7 +236,7 @@ transaction = (
         # optional and does not affect how Stellar treats the transaction.
         .add_text_memo("Test Transaction")
         # Wait a maximum of three minutes for the transaction
-        .set_timeout(10)
+        .set_timeout(180)
         .build()
 )
 


### PR DESCRIPTION
The Python example was calling `set_timeout(10)` but the comment said it was a maximum of 3 minutes. Fix code to set timeout to 180 seconds.