### PR TITLE
change Ruby links to point to astroband org

### DIFF
--- a/guides/get-started/readme.md
+++ b/guides/get-started/readme.md
@@ -11,7 +11,7 @@ Using the Stellar network, you can build mobile wallets, banking tools, smart de
 
 The easiest way to install Horizon is by using the [**stellar/quickstart** docker image](https://hub.docker.com/r/stellar/quickstart/).
 
-Stellar.org maintains [JavaScript](https://github.com/stellar/js-stellar-sdk), [Java](https://github.com/stellar/java-stellar-sdk), and [Go](https://github.com/stellar/go/tree/master/clients/horizon)-based SDKs for communicating with Horizon. There are also community-maintained SDKs for [Ruby](https://github.com/stellar/ruby-stellar-sdk), [Python](https://github.com/StellarCN/py-stellar-base), and [C#](https://github.com/elucidsoft/dotnet-stellar-sdk).
+Stellar.org maintains [JavaScript](https://github.com/stellar/js-stellar-sdk), [Java](https://github.com/stellar/java-stellar-sdk), and [Go](https://github.com/stellar/go/tree/master/clients/horizon)-based SDKs for communicating with Horizon. There are also community-maintained SDKs for [Ruby](https://github.com/astroband/ruby-stellar-sdk), [Python](https://github.com/StellarCN/py-stellar-base), and [C#](https://github.com/elucidsoft/dotnet-stellar-sdk).
 
 ## Network Backbone: Stellar Core
 

--- a/reference/readme.md
+++ b/reference/readme.md
@@ -16,10 +16,10 @@ Libraries maintained by Stellar.org:<br />
 - [Java](https://github.com/stellar/java-stellar-sdk)
 - [Go](https://github.com/stellar/go)
 
-Community-maintained libraries (in various states of completion) for interacting with Horizon in other languages:<br>
+Community-maintained libraries for interacting with Horizon in other languages:<br>
 - [Python](https://github.com/StellarCN/py-stellar-base)
 - [C# .NET Standard 2.0](https://github.com/elucidsoft/dotnetcore-stellar-sdk)
 - [C++](https://github.com/bnogalm/StellarQtSDK)
 - [Scala](https://github.com/Synesso/scala-stellar-sdk)
-- [Ruby](https://github.com/bloom-solutions/ruby-stellar-sdk)
+- [Ruby](https://github.com/astroband/ruby-stellar-sdk)
 - [iOS & macOS](https://github.com/Soneso/stellar-ios-mac-sdk)

--- a/translations/pt-BR/guides/get-started/readme.md
+++ b/translations/pt-BR/guides/get-started/readme.md
@@ -11,7 +11,7 @@ Usando a rede Stellar, você pode construir wallets para celular, ferramentas ba
 
 A maneira mais fácil de instalar o Horizon é usando a [imagem **stellar/quickstart** do docker](https://hub.docker.com/r/stellar/quickstart/).
 
-O Stellar.org mantém SDKs baseados em [JavaScript](https://github.com/stellar/js-stellar-sdk), [Java](https://github.com/stellar/java-stellar-sdk) e [Go](https://github.com/stellar/go/tree/master/clients/horizon) para comunicar-se com o Horizon. Também há SDKs mantidos pela comunidade para [Ruby](https://github.com/stellar/ruby-stellar-sdk), [Python](https://github.com/StellarCN/py-stellar-base) e [C#](https://github.com/QuantozTechnology/csharp-stellar-base).
+O Stellar.org mantém SDKs baseados em [JavaScript](https://github.com/stellar/js-stellar-sdk), [Java](https://github.com/stellar/java-stellar-sdk) e [Go](https://github.com/stellar/go/tree/master/clients/horizon) para comunicar-se com o Horizon. Também há SDKs mantidos pela comunidade para [Ruby](https://github.com/astroband/ruby-stellar-sdk), [Python](https://github.com/StellarCN/py-stellar-base) e [C#](https://github.com/QuantozTechnology/csharp-stellar-base).
 
 ## A Base da Rede: Stellar Core
 


### PR DESCRIPTION
Evil Martians (https://github.com/astroband/) have now taken ownership of the Ruby SDK. Update links to point at the [new repo location](https://github.com/astroband/ruby-stellar-sdk).